### PR TITLE
Sprint5 issue71 tacoury Scrolling of Comments

### DIFF
--- a/FlippedTech/flippedtech/src/components/Comments/CommentBox.js
+++ b/FlippedTech/flippedtech/src/components/Comments/CommentBox.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import CommentForm from './CommentForm';
 import CommentList from './CommentList';
 import 'tachyons';
+import './cssComments/myBox.css'
 
 class CommentBox extends Component {
   //constructor applies necessary data to the component
@@ -69,12 +70,14 @@ class CommentBox extends Component {
 
 	render() {
  		return(
- 			<div className='b--solid tc'>
- 				<h1>Comment Box</h1>
- 				<CommentList lists = {this.state.commentlist}></CommentList>
- 				<h1></h1>
- 				<CommentForm handler = {this.addComment} />
- 			</div>
+			 			<div className='b--solid tc container'>
+			 				<h1>Comment Box</h1>
+							<div class="myBox">
+			 				<CommentList lists = {this.state.commentlist}></CommentList>
+			 				<h1></h1>
+							</div>
+			 				<CommentForm handler = {this.addComment} />
+			 			</div>
    	);
 	}
 }

--- a/FlippedTech/flippedtech/src/components/Comments/CommentBox.js
+++ b/FlippedTech/flippedtech/src/components/Comments/CommentBox.js
@@ -72,7 +72,7 @@ class CommentBox extends Component {
  		return(
 			 			<div className='b--solid tc container'>
 			 				<h1>Comment Box</h1>
-							<div class="myBox">
+							<div class="myBox center">
 			 				<CommentList lists = {this.state.commentlist}></CommentList>
 			 				<h1></h1>
 							</div>

--- a/FlippedTech/flippedtech/src/components/Comments/cssComments/myBox.css
+++ b/FlippedTech/flippedtech/src/components/Comments/cssComments/myBox.css
@@ -1,0 +1,28 @@
+.myBox {
+border: none;
+padding: 5px;
+font: 12px/18px sans-serif;
+width: 1175px;
+height: 150px;
+overflow: scroll;
+}
+
+/* Scrollbar styles */
+::-webkit-scrollbar {
+width: 12px;
+height: 12px;
+}
+
+::-webkit-scrollbar-track {
+background: #f5f5f5;
+border-radius: 10px;
+}
+
+::-webkit-scrollbar-thumb {
+border-radius: 10px;
+background: #ccc;
+}
+
+::-webkit-scrollbar-thumb:hover {
+background: #999;
+}

--- a/FlippedTech/flippedtech/src/components/Comments/cssComments/myBox.css
+++ b/FlippedTech/flippedtech/src/components/Comments/cssComments/myBox.css
@@ -7,6 +7,12 @@ height: 150px;
 overflow: scroll;
 }
 
+.center {
+    margin: auto;
+    width: 90%;
+    padding: 10px;
+}
+
 /* Scrollbar styles */
 ::-webkit-scrollbar {
 width: 12px;


### PR DESCRIPTION
I changed the styling of the comments a little bit so that you do not have to scroll all the way through them to get to the comment form. You can still scroll through the comments just in their own component. 